### PR TITLE
Add priority fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,60 @@
+# http://www.gnu.org/software/automake
+
+Makefile.in
+/ar-lib
+/mdate-sh
+/py-compile
+/test-driver
+/ylwrap
+
+# http://www.gnu.org/software/autoconf
+
+autom4te.cache
+/autoscan.log
+/autoscan-*.log
+/aclocal.m4
+/compile
+/config.guess
+/config.h.in
+/config.log
+/config.status
+/config.sub
+/configure
+/configure.scan
+/depcomp
+/install-sh
+/missing
+/stamp-h1
+
+# https://www.gnu.org/software/libtool/
+
+/ltmain.sh
+
+# http://www.gnu.org/software/texinfo
+
+/texinfo.tex
+
+# http://www.gnu.org/software/m4/
+
+m4/libtool.m4
+m4/ltoptions.m4
+m4/ltsugar.m4
+m4/ltversion.m4
+m4/lt~obsolete.m4
+
+## Other
+
+*~
+*.o
+*.lo
+*.la
+\#*
+
+Makefile
+doc/devtodo.1
+makepackages.sh
+devtodo.spec
+devtodo.list
+config.h
+libtool
+.deps/

--- a/src/TodoDB.cc
+++ b/src/TodoDB.cc
@@ -506,8 +506,8 @@ string priority;
 		} else
 			priority = current;
 		priority = trim(priority);
-		// Default to medium
-		if (priority == "") priority = "medium";
+		// Default to medium or current
+		if (priority == "") priority = current;
 		try {
 			if (priority.size() == 1 && isdigit(priority[0])) {
 			int index = destringify<int>(priority);

--- a/src/support.cc
+++ b/src/support.cc
@@ -734,8 +734,7 @@ static int init_rl() {
 string readText(string const &prompt, string existing) {
 string out;
 
-	rl_startup_hook = (int(*)(const char*, int))init_rl;
-
+	rl_startup_hook = (int(*)())init_rl;
 	rl_buffer = &existing;
 char const *tmp = readline(const_cast<char*>(prompt.c_str()));
 	if (tmp) out = tmp;


### PR DESCRIPTION
Hi again, Alec.

It's been a while - life was chaotic this year. This PR has 3 commits:

- d26d6cef3fa2934a29d98eff70971ff04fe6e93b adds a gitignore to easy devlopment
- f2ba44b00678f09f59372e8090baacc4df791508 fixes a bug during a cast (thanks to gcc for shouting)
- aa0383f421ca0648d5710d9b2689e0ad39b63413 change the behaviour when adding a task. Instead of defaulting to `medium`, it takes into account the parent priority first (if there's no parent, defaults to medium)

Hopefully there is no major mistake here and you can merge this PR. This will fix #4 (we are using libedit compatibility layer and the license problem is solved :-)

Also, if you could make a new release after merging, it would be awesome and make my life easier (for packaging to Debian)